### PR TITLE
Preventing supports tests from being wrapped in ()

### DIFF
--- a/gumby.images.js
+++ b/gumby.images.js
@@ -159,8 +159,9 @@
 			str = str.replace('>', 'min-width: ').replace('<', 'max-width: ');
 		}
 
-		// check if media query wrapped in ()
-		if(str.charAt(0) !== '(' && str.charAt(str.length - 1) !== ')') {
+		// check if media query (prevent wrapping feature detection tests) AND if media query, wrapped in ()
+ 		if(str.indexOf('width') > -1 
+ 				&& str.charAt(0) !== '(' && str.charAt(str.length - 1) !== ')') {
 			str = '('+str+')';
 		}
 


### PR DESCRIPTION
The shorthand method is called on all tests, this.supports as well as this.media. Only this.media testst should be wrapped in () by the shorthand method. Including an extra test for 'width' being present in the tested string prevents supports tests from begin wrapped into e.d. '(webp)', and thus causing false negatives.

(now on develop branch instead of earlier pull request on master)
